### PR TITLE
swift5.1 requires FoundationNetworking in order to use URLSession

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ EXAMPLE_PROJECT_PATH=Examples/SquareNumber
 LAMBDA_ZIP=lambda.zip
 SHARED_LIBS_FOLDER=swift-shared-libs
 LAYER_ZIP=swift-lambda-runtime.zip
-SWIFT_DOCKER_IMAGE=swift:5.0
+SWIFT_DOCKER_IMAGE=swift:5.1
 
 clean_lambda:
 	rm $(LAMBDA_ZIP) || true
@@ -64,6 +64,7 @@ package_layer: clean_layer
 					/lib/x86_64-linux-gnu/libz.so.1 \
 					/usr/lib/swift/linux/libBlocksRuntime.so \
 					/usr/lib/swift/linux/libFoundation.so \
+					/usr/lib/swift/linux/libFoundationNetworking.so \
 					/usr/lib/swift/linux/libdispatch.so \
 					/usr/lib/swift/linux/libicudataswift.so.61 \
 					/usr/lib/swift/linux/libicui18nswift.so.61 \

--- a/Sources/AWSLambdaSwift/Runtime.swift
+++ b/Sources/AWSLambdaSwift/Runtime.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if swift(>=5.1) && os(Linux)
+  import FoundationNetworking
+#endif
 
 public func log(_ object: Any, flush: Bool = false) {
     fputs("\(object)\n", stderr)

--- a/Sources/AWSLambdaSwift/URLSession+Utils.swift
+++ b/Sources/AWSLambdaSwift/URLSession+Utils.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if swift(>=5.1) && os(Linux)
+  import FoundationNetworking
+#endif
 
 extension URLSession {
     func synchronousDataTask(with url: URL) -> (Data?, URLResponse?, Error?) {


### PR DESCRIPTION
When compiling `aws-lmabda-swift` with swift5.1 one gets tons of errors like this:

```
Foundation.URLSession:2:18: note: 'URLSession' has been explicitly marked unavailable here
public typealias URLSession = AnyObject
                 ^
/src/.build/checkouts/aws-lambda-swift/Sources/AWSLambdaSwift/URLSession+Utils.swift:4:56: error: 'URLResponse' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.
```

The rationale for this change in swift can be found here:
https://forums.swift.org/t/pitch-move-urlsession-to-new-foundationnetworking-module/14002

This pr imports FoundationNetwork in swift5.1 on Linux. Therefore it guaranties, compiling in swift5.1 on tuxOS.